### PR TITLE
Allow to copy .iso file

### DIFF
--- a/TeconMoon's WiiVC Injector/Form1.Designer.cs
+++ b/TeconMoon's WiiVC Injector/Form1.Designer.cs
@@ -90,6 +90,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.SaveAncastKeyButton = new System.Windows.Forms.Button();
             this.DisableNintendontAutoboot = new System.Windows.Forms.CheckBox();
+            this.CopyIso = new System.Windows.Forms.CheckBox();
             this.DisableTrimming = new System.Windows.Forms.CheckBox();
             this.Force43NAND = new System.Windows.Forms.CheckBox();
             this.DisablePassthrough = new System.Windows.Forms.CheckBox();
@@ -800,6 +801,7 @@
             this.AdvancedTab.Controls.Add(this.label2);
             this.AdvancedTab.Controls.Add(this.SaveAncastKeyButton);
             this.AdvancedTab.Controls.Add(this.DisableNintendontAutoboot);
+            this.AdvancedTab.Controls.Add(this.CopyIso);
             this.AdvancedTab.Controls.Add(this.DisableTrimming);
             this.AdvancedTab.Controls.Add(this.Force43NAND);
             this.AdvancedTab.Controls.Add(this.DisablePassthrough);
@@ -886,6 +888,17 @@
             this.DisableNintendontAutoboot.Text = "Disable Autoboot";
             this.DisableNintendontAutoboot.UseVisualStyleBackColor = true;
             this.DisableNintendontAutoboot.CheckedChanged += new System.EventHandler(this.NintendontAutoboot_CheckedChanged);
+            // 
+            // Copy iso
+            // 
+            this.CopyIso.AutoSize = true;
+            this.CopyIso.Location = new System.Drawing.Point(225, 70);
+            this.CopyIso.Name = "CopyIso";
+            this.CopyIso.Size = new System.Drawing.Size(107, 17);
+            this.CopyIso.TabIndex = 22;
+            this.CopyIso.Text = "Copy .iso";
+            this.CopyIso.UseVisualStyleBackColor = true;
+            this.CopyIso.CheckedChanged += new System.EventHandler(this.CopyIso_CheckedChanged);
             // 
             // DisableTrimming
             // 
@@ -1437,6 +1450,7 @@
         private System.Windows.Forms.RadioButton ForceNoCC;
         private System.Windows.Forms.Button RepoDownload;
         private System.Windows.Forms.CheckBox DisableNintendontAutoboot;
+        private System.Windows.Forms.CheckBox CopyIso;
         private System.Windows.Forms.OpenFileDialog OpenMainDol;
         private System.Windows.Forms.Button SaveAncastKeyButton;
         private System.Windows.Forms.Button SaveTitleKeyButton;

--- a/TeconMoon's WiiVC Injector/Form1.cs
+++ b/TeconMoon's WiiVC Injector/Form1.cs
@@ -293,6 +293,8 @@ namespace TeconMoon_s_WiiVC_Injector
                 CustomMainDol.Enabled = false;
                 DisableNintendontAutoboot.Checked = false;
                 DisableNintendontAutoboot.Enabled = false;
+                CopyIso.Checked = false;
+                CopyIso.Enabled = false;
                 DisablePassthrough.Checked = false;
                 DisablePassthrough.Enabled = false;
                 DisableGamePad.Checked = false;
@@ -351,6 +353,8 @@ namespace TeconMoon_s_WiiVC_Injector
                 CustomMainDol.Enabled = false;
                 DisableNintendontAutoboot.Checked = false;
                 DisableNintendontAutoboot.Enabled = false;
+                CopyIso.Checked = false;
+                CopyIso.Enabled = false;
                 DisablePassthrough.Enabled = true;
                 DisableGamePad.Enabled = true;
                 C2WPatchFlag.Enabled = true;
@@ -393,6 +397,8 @@ namespace TeconMoon_s_WiiVC_Injector
                 CustomMainDol.Enabled = false;
                 DisableNintendontAutoboot.Checked = false;
                 DisableNintendontAutoboot.Enabled = false;
+                CopyIso.Checked = false;
+                CopyIso.Enabled = false;
                 DisablePassthrough.Checked = false;
                 DisablePassthrough.Enabled = false;
                 DisableGamePad.Checked = false;
@@ -490,6 +496,7 @@ namespace TeconMoon_s_WiiVC_Injector
                 ForceInterlacedNINTENDONT.Enabled = true;
                 CustomMainDol.Enabled = true;
                 DisableNintendontAutoboot.Enabled = true;
+                CopyIso.Enabled = true;
                 DisablePassthrough.Checked = false;
                 DisablePassthrough.Enabled = false;
                 DisableGamePad.Enabled = true;
@@ -1371,6 +1378,10 @@ namespace TeconMoon_s_WiiVC_Injector
                 CustomMainDol.Enabled = true;
             }
         }
+        private void CopyIso_CheckedChanged(object sender, EventArgs e)
+        {
+            // Stub
+        }
         private void MainDolSourceButton_Click(object sender, EventArgs e)
         {
             if (OpenMainDol.ShowDialog() == DialogResult.OK)
@@ -2112,7 +2123,7 @@ namespace TeconMoon_s_WiiVC_Injector
                     File.Copy(TempToolsPath + "DOL\\nintendont_default_autobooter.dol", TempSourcePath + "TEMPISOBASE\\sys\\main.dol");
                 }
 
-                if (FlagNKIT)
+                if (FlagNKIT && !CopyIso.Checked)
                 {
                     if (Directory.Exists(TempToolsPath + "NKIT\\Processed\\Temp"))
                     {
@@ -2132,7 +2143,7 @@ namespace TeconMoon_s_WiiVC_Injector
 
                 if (FlagGC2Specified)
                 {
-                    if (FlagNKIT)
+                    if (FlagNKIT && !CopyIso.Checked)
                     {
                         if (Directory.Exists(TempToolsPath + "NKIT\\Processed\\Temp"))
                         {


### PR DESCRIPTION
This allows to copy i.E. nkit isos directly into the inject.

Size comparision with Animal Crossing (EUR / GAFP)
Unscrubbed: 1.44 GB
NKIT copied: 156.41 MB

Installed sizes (above NKIT copied, below unscrubbed) :
![image](https://github.com/piratesephiroth/TeconmoonWiiVCInjector/assets/1312422/690f7565-e054-496f-b4de-be68993db167)
